### PR TITLE
support for autoform 5+, which contains some breaking changes

### DIFF
--- a/ionic.html
+++ b/ionic.html
@@ -45,26 +45,26 @@
   {{else}}
     <label {{ionicFieldLabelAtts}}>
       {{#unless ionicFieldLabelAtts.placeholderOnly}}
-        <span class="input-label">{{#if this.labelText}}{{this.labelText}}{{else}}{{afFieldLabelText name=this.atts.name}}{{/if}}</span>
+        <span class="input-label">{{#if this.labelText}}{{this.labelText}}{{else}}{{afFieldLabelText name=this.name}}{{/if}}</span>
       {{/unless}}
       {{> afFieldInput this.afFieldInputAtts}}
     </label>
   {{/if}}
-  {{#if afFieldIsInvalid name=this.atts.name}}
-    <div class="item item-text-wrap assertive"><i class="icon ion-android-alert"></i> {{{afFieldMessage name=this.atts.name}}}</div>
+  {{#if afFieldIsInvalid name=this.name}}
+    <div class="item item-text-wrap assertive"><i class="icon ion-android-alert"></i> {{{afFieldMessage name=this.name}}}</div>
   {{/if}}
 </template>
 
 <template name="afObjectField_ionic">
-  {{#with afFieldLabelText name=this.atts.name}}
+  {{#with afFieldLabelText name=this.name}}
     <div class="item item-divider">
       {{this}}
     </div>
   {{/with}}
-  {{#if afFieldIsInvalid name=this.atts.name}}
-    <div class="assertive">{{{afFieldMessage name=this.atts.name}}}</div>
+  {{#if afFieldIsInvalid name=this.name}}
+    <div class="assertive">{{{afFieldMessage name=this.name}}}</div>
   {{/if}}
-  {{> afQuickFields name=this.atts.name}}
+  {{> afQuickFields name=this.name}}
 </template>
 
 <template name="afArrayField_ionic">

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom("1.0");
   api.use(["templating", "underscore"], "client");
-  api.use("aldeed:autoform@4.2.0");
+  api.use("aldeed:autoform@4.2.0 || 5.0.0");
   api.addFiles([
     "ionic.html",
     "ionic.css",


### PR DESCRIPTION
Autoform 5.0 came out, with a number of breaking changes: https://github.com/aldeed/meteor-autoform#note-autoform-50.

This is an initiative to make autoform-ionic compatible with the latest version of autoform. It is a work in progress — I’ve just started using this package, so I cannot test all the functionality yet.

---

This commit includes a fix for the following change:
- Compatibility break: If you have custom templates for afFormGroup or afObjectField, change all this.atts references to this.

All breaking changes: https://github.com/aldeed/meteor-autoform/blob/master/CHANGELOG.md#500
