### PR TITLE
Fixed some issues regarding object types in Autoform 5.

### DIFF
--- a/ionic.html
+++ b/ionic.html
@@ -45,26 +45,26 @@
   {{else}}
     <label {{ionicFieldLabelAtts}}>
       {{#unless ionicFieldLabelAtts.placeholderOnly}}
-        <span class="input-label">{{#if this.labelText}}{{this.labelText}}{{else}}{{afFieldLabelText name=this.atts.name}}{{/if}}</span>
+        <span class="input-label">{{#if this.labelText}}{{this.labelText}}{{else}}{{afFieldLabelText name=this.name}}{{/if}}</span>
       {{/unless}}
       {{> afFieldInput this.afFieldInputAtts}}
     </label>
   {{/if}}
-  {{#if afFieldIsInvalid name=this.atts.name}}
-    <div class="item item-text-wrap assertive"><i class="icon ion-android-alert"></i> {{{afFieldMessage name=this.atts.name}}}</div>
+  {{#if afFieldIsInvalid name=this.name}}
+    <div class="item item-text-wrap assertive"><i class="icon ion-android-alert"></i> {{{afFieldMessage name=this.name}}}</div>
   {{/if}}
 </template>
 
 <template name="afObjectField_ionic">
-  {{#with afFieldLabelText name=this.atts.name}}
+  {{#with afFieldLabelText name=this.name}}
     <div class="item item-divider">
       {{this}}
     </div>
   {{/with}}
-  {{#if afFieldIsInvalid name=this.atts.name}}
-    <div class="assertive">{{{afFieldMessage name=this.atts.name}}}</div>
+  {{#if afFieldIsInvalid name=this.name}}
+    <div class="assertive">{{{afFieldMessage name=this.name}}}</div>
   {{/if}}
-  {{> afQuickFields name=this.atts.name}}
+  {{> afQuickFields name=this.name}}
 </template>
 
 <template name="afArrayField_ionic">

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom("1.0");
   api.use(["templating", "underscore"], "client");
-  api.use("aldeed:autoform@5.2.0");
+  api.use("aldeed:autoform@5.3.0");
   api.addFiles([
     "ionic.html",
     "ionic.css",


### PR DESCRIPTION
I noticed the same issue as https://github.com/meteoric/autoform-ionic/issues/16, its due to the name is not in atts anymore, I've updated where appropriate to fix this.
